### PR TITLE
Add Anitya external version checker

### DIFF
--- a/com.w1hkj.fldigi.yml
+++ b/com.w1hkj.fldigi.yml
@@ -39,8 +39,8 @@ modules:
   - name: fldigi
     sources:
       - type: archive
-        url: http://www.w1hkj.com/files/fldigi/fldigi-4.1.16.tar.gz
-        sha256: 640e3ea544adc7696e18cb08ed311ae1971ed18c609c39b55fb3c40c34dcd3b5
+        url: http://www.w1hkj.com/files/fldigi/fldigi-4.1.18.tar.gz
+        sha256: 3c7fd84ab3a84ba4525b251e9d56120daee626a3831684a974fdad476f90270d
         x-checker-data:
           type: anitya
           project-id: 818

--- a/com.w1hkj.fldigi.yml
+++ b/com.w1hkj.fldigi.yml
@@ -41,6 +41,10 @@ modules:
       - type: archive
         url: http://www.w1hkj.com/files/fldigi/fldigi-4.1.16.tar.gz
         sha256: 640e3ea544adc7696e18cb08ed311ae1971ed18c609c39b55fb3c40c34dcd3b5
+        x-checker-data:
+          type: anitya
+          project-id: 818
+          url-template: http://www.w1hkj.com/files/fldigi/fldigi-$version.tar.gz
   - name: metainfo
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
This should let https://github.com/flathub/flatpak-external-data-checker automatically file issues when the upstream version is updated. This tracks fldigi via https://release-monitoring.org/project/818/